### PR TITLE
Add demo data filling across forms

### DIFF
--- a/application/foodtrace-ledger-supply/src/components/ArchiveShipmentForm.tsx
+++ b/application/foodtrace-ledger-supply/src/components/ArchiveShipmentForm.tsx
@@ -5,7 +5,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
 import { apiClient } from '@/services/api';
 import { useToast } from '@/hooks/use-toast';
-import { Package, X } from 'lucide-react';
+import { Package, X, TestTubeDiagonal } from 'lucide-react';
 
 interface ArchiveShipmentFormProps {
   shipmentId: string;
@@ -17,6 +17,11 @@ const ArchiveShipmentForm: React.FC<ArchiveShipmentFormProps> = ({ shipmentId, o
   const { toast } = useToast();
   const [reason, setReason] = useState('');
   const [loading, setLoading] = useState(false);
+
+  const fillWithDemoData = () => {
+    setReason('Demo archive - obsolete data');
+    toast({ title: 'Demo data loaded' });
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -44,6 +49,10 @@ const ArchiveShipmentForm: React.FC<ArchiveShipmentFormProps> = ({ shipmentId, o
           <span>Archive Shipment</span>
         </CardTitle>
         <CardDescription>Provide a reason for archiving.</CardDescription>
+        <Button type="button" variant="outline" onClick={fillWithDemoData} className="mt-2 text-sm">
+          <TestTubeDiagonal className="h-4 w-4 mr-2" />
+          Fill with Demo Data
+        </Button>
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit} className="space-y-4">

--- a/application/foodtrace-ledger-supply/src/components/AssignRoleForm.tsx
+++ b/application/foodtrace-ledger-supply/src/components/AssignRoleForm.tsx
@@ -5,7 +5,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { apiClient } from '@/services/api';
 import { useToast } from '@/hooks/use-toast';
 import { Label } from '@/components/ui/label';
-import { X, UserPlus } from 'lucide-react';
+import { X, UserPlus, TestTubeDiagonal } from 'lucide-react';
 
 interface AssignRoleFormProps {
   identities: any[];
@@ -18,6 +18,14 @@ const AssignRoleForm: React.FC<AssignRoleFormProps> = ({ identities, onSuccess, 
   const [alias, setAlias] = useState('');
   const [role, setRole] = useState('farmer');
   const [loading, setLoading] = useState(false);
+
+  const fillWithDemoData = () => {
+    if (identities.length > 0) {
+      setAlias(identities[0].enrollmentID || identities[0].alias);
+    }
+    setRole('farmer');
+    toast({ title: 'Demo data loaded' });
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -42,6 +50,10 @@ const AssignRoleForm: React.FC<AssignRoleFormProps> = ({ identities, onSuccess, 
           <span>Assign Role</span>
         </CardTitle>
         <CardDescription>Select an identity and role</CardDescription>
+        <Button type="button" variant="outline" onClick={fillWithDemoData} className="mt-2 text-sm">
+          <TestTubeDiagonal className="h-4 w-4 mr-2" />
+          Fill with Demo Data
+        </Button>
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit} className="space-y-4">

--- a/application/foodtrace-ledger-supply/src/components/DistributeShipmentForm.tsx
+++ b/application/foodtrace-ledger-supply/src/components/DistributeShipmentForm.tsx
@@ -8,7 +8,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { apiClient } from '@/services/api';
 import { useToast } from '@/hooks/use-toast';
 import { useAliases } from '@/hooks/use-aliases';
-import { Truck, X } from 'lucide-react';
+import { Truck, X, TestTubeDiagonal } from 'lucide-react';
 
 interface DistributeShipmentFormProps {
   shipmentId: string;
@@ -38,6 +38,23 @@ const DistributeShipmentForm: React.FC<DistributeShipmentFormProps> = ({
 
   const handleInputChange = (field: keyof typeof formData, value: string) => {
     setFormData(prev => ({ ...prev, [field]: value }));
+  };
+
+  const fillWithDemoData = () => {
+    const now = new Date();
+    const delivery = new Date(now.getTime() + 6 * 60 * 60 * 1000);
+    setFormData({
+      pickupDateTime: now.toISOString().slice(0,16),
+      deliveryDateTime: delivery.toISOString().slice(0,16),
+      transportConditions: 'Refrigerated',
+      temperatureRange: '2-8°C',
+      storageTemperature: '5',
+      distributionCenter: 'Demo DC',
+      distributionLineId: 'TRUCK_DEMO_1',
+      transitLocationLog: 'Warehouse A, Hub B',
+      destinationRetailerId: retailerAliases[0] || ''
+    });
+    toast({ title: 'Demo data loaded' });
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -130,6 +147,10 @@ const DistributeShipmentForm: React.FC<DistributeShipmentFormProps> = ({
         <CardDescription>
           Enter distribution and transport details. All fields marked with * are required.
         </CardDescription>
+        <Button type="button" variant="outline" onClick={fillWithDemoData} className="mt-2 text-sm">
+          <TestTubeDiagonal className="h-4 w-4 mr-2" />
+          Fill with Demo Data
+        </Button>
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit} className="space-y-4">

--- a/application/foodtrace-ledger-supply/src/components/ProcessShipmentForm.tsx
+++ b/application/foodtrace-ledger-supply/src/components/ProcessShipmentForm.tsx
@@ -8,7 +8,7 @@ import { Textarea } from '@/components/ui/textarea'; // For qualityCertification
 import { apiClient } from '@/services/api';
 import { useToast } from '@/hooks/use-toast';
 import { useAliases } from '@/hooks/use-aliases';
-import { CheckCircle, X } from 'lucide-react';
+import { CheckCircle, X, TestTubeDiagonal } from 'lucide-react';
 
 interface ProcessShipmentFormProps {
   shipmentId: string;
@@ -38,6 +38,24 @@ const ProcessShipmentForm: React.FC<ProcessShipmentFormProps> = ({
 
   const handleInputChange = (field: keyof typeof formData, value: string) => {
     setFormData(prev => ({ ...prev, [field]: value }));
+  };
+
+  const fillWithDemoData = () => {
+    const now = new Date();
+    const expiry = new Date();
+    expiry.setDate(now.getDate() + 30);
+    setFormData({
+      processingType: 'Demo Washing',
+      processingLineId: 'LINE_DEMO_1',
+      dateProcessed: now.toISOString().slice(0,16),
+      contaminationCheck: 'PASSED',
+      outputBatchId: 'DEMO_BATCH_001',
+      expiryDate: expiry.toISOString().slice(0,10),
+      processingLocation: 'Demo Facility',
+      qualityCertifications: 'Organic,HACCP',
+      destinationDistributorId: distributorAliases[0] || ''
+    });
+    toast({ title: 'Demo data loaded' });
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -136,6 +154,10 @@ const ProcessShipmentForm: React.FC<ProcessShipmentFormProps> = ({
         <CardDescription>
           Enter processing details for this shipment. All fields marked with * are required.
         </CardDescription>
+        <Button type="button" variant="outline" onClick={fillWithDemoData} className="mt-2 text-sm">
+          <TestTubeDiagonal className="h-4 w-4 mr-2" />
+          Fill with Demo Data
+        </Button>
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit} className="space-y-4">

--- a/application/foodtrace-ledger-supply/src/components/RecallForm.tsx
+++ b/application/foodtrace-ledger-supply/src/components/RecallForm.tsx
@@ -5,7 +5,7 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { useToast } from '@/hooks/use-toast';
 import { apiClient } from '@/services/api';
-import { AlertTriangle, X } from 'lucide-react';
+import { AlertTriangle, X, TestTubeDiagonal } from 'lucide-react';
 
 interface RecallFormProps {
   shipmentId: string;
@@ -20,6 +20,14 @@ const RecallForm: React.FC<RecallFormProps> = ({ shipmentId, onSuccess, onCancel
   const [related, setRelated] = useState<any[]>([]);
   const [relatedLoading, setRelatedLoading] = useState(true);
   const [selected, setSelected] = useState<string[]>([]);
+
+  const fillWithDemoData = () => {
+    setReason('Demo recall due to quality issue');
+    if (related.length > 0) {
+      setSelected([related[0].shipmentId]);
+    }
+    toast({ title: 'Demo data loaded' });
+  };
 
   useEffect(() => {
     const load = async () => {
@@ -75,6 +83,10 @@ const RecallForm: React.FC<RecallFormProps> = ({ shipmentId, onSuccess, onCancel
           This creates a new recall event for the selected shipment. Any boxes you
           check below will be linked to that event after it is created.
         </CardDescription>
+        <Button type="button" variant="outline" onClick={fillWithDemoData} className="mt-2 text-sm">
+          <TestTubeDiagonal className="h-4 w-4 mr-2" />
+          Fill with Demo Data
+        </Button>
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit} className="space-y-4">

--- a/application/foodtrace-ledger-supply/src/components/ReceiveShipmentForm.tsx
+++ b/application/foodtrace-ledger-supply/src/components/ReceiveShipmentForm.tsx
@@ -5,7 +5,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { apiClient } from '@/services/api';
 import { useToast } from '@/hooks/use-toast';
-import { Building, X } from 'lucide-react';
+import { Building, X, TestTubeDiagonal } from 'lucide-react';
 
 interface ReceiveShipmentFormProps {
   shipmentId: string;
@@ -35,6 +35,27 @@ const ReceiveShipmentForm: React.FC<ReceiveShipmentFormProps> = ({
 
   const handleInputChange = (field: keyof typeof formData, value: string) => {
     setFormData(prev => ({ ...prev, [field]: value }));
+  };
+
+  const fillWithDemoData = () => {
+    const now = new Date();
+    const sellBy = new Date(now);
+    sellBy.setDate(now.getDate() + 7);
+    const expiry = new Date(now);
+    expiry.setDate(now.getDate() + 10);
+    setFormData({
+      dateReceived: now.toISOString().slice(0,16),
+      retailerLineId: 'RETL_DEMO_1',
+      productNameRetail: 'Demo Retail Product',
+      shelfLife: '7 days',
+      sellByDate: sellBy.toISOString().slice(0,10),
+      retailerExpiryDate: expiry.toISOString().slice(0,10),
+      storeId: 'STORE_DEMO_1',
+      storeLocation: 'Demo City',
+      price: '9.99',
+      qrCodeLink: 'https://demo.example.com/track'
+    });
+    toast({ title: 'Demo data loaded' });
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -138,6 +159,10 @@ const ReceiveShipmentForm: React.FC<ReceiveShipmentFormProps> = ({
         <CardDescription>
           Enter retail information for the received shipment. All fields marked with * are required.
         </CardDescription>
+        <Button type="button" variant="outline" onClick={fillWithDemoData} className="mt-2 text-sm">
+          <TestTubeDiagonal className="h-4 w-4 mr-2" />
+          Fill with Demo Data
+        </Button>
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit} className="space-y-4">

--- a/application/foodtrace-ledger-supply/src/components/RecordCertificationForm.tsx
+++ b/application/foodtrace-ledger-supply/src/components/RecordCertificationForm.tsx
@@ -7,7 +7,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Textarea } from '@/components/ui/textarea';
 import { apiClient } from '@/services/api';
 import { useToast } from '@/hooks/use-toast';
-import { ShieldCheck, X } from 'lucide-react';
+import { ShieldCheck, X, TestTubeDiagonal } from 'lucide-react';
 
 interface RecordCertificationFormProps {
   shipmentId: string;
@@ -35,6 +35,17 @@ const RecordCertificationForm: React.FC<RecordCertificationFormProps> = ({
 
   const handleSelectChange = (field: string, value: string) => {
     setFormData(prev => ({ ...prev, [field]: value }));
+  };
+
+  const fillWithDemoData = () => {
+    const now = new Date();
+    setFormData({
+      inspectionDate: now.toISOString().slice(0,16),
+      inspectionReportHash: 'demo_hash_123',
+      certificationStatus: 'APPROVED',
+      comments: 'All standards met.'
+    });
+    toast({ title: 'Demo data loaded' });
   };
 
 
@@ -103,6 +114,10 @@ const RecordCertificationForm: React.FC<RecordCertificationFormProps> = ({
         <CardDescription>
           Record the certification inspection results for this shipment.
         </CardDescription>
+        <Button type="button" variant="outline" onClick={fillWithDemoData} className="mt-2 text-sm">
+          <TestTubeDiagonal className="h-4 w-4 mr-2" />
+          Fill with Demo Data
+        </Button>
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit} className="space-y-4">

--- a/application/foodtrace-ledger-supply/src/components/TransformProductsForm.tsx
+++ b/application/foodtrace-ledger-supply/src/components/TransformProductsForm.tsx
@@ -8,7 +8,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { useToast } from '@/hooks/use-toast';
 import { apiClient } from '@/services/api';
 import { useAliases } from '@/hooks/use-aliases';
-import { ArrowRight, X } from 'lucide-react';
+import { ArrowRight, X, TestTubeDiagonal } from 'lucide-react';
 
 interface TransformProductsFormProps {
   shipmentId: string;
@@ -36,6 +36,26 @@ const TransformProductsForm: React.FC<TransformProductsFormProps> = ({ shipmentI
 
   const handleChange = (field: keyof typeof formData, value: string) => {
     setFormData(prev => ({ ...prev, [field]: value }));
+  };
+
+  const fillWithDemoData = () => {
+    const now = new Date();
+    const exp = new Date();
+    exp.setDate(now.getDate() + 365);
+    setFormData({
+      newShipmentId: '',
+      productName: 'Demo Derived Product',
+      description: 'Sample transformed goods',
+      quantity: '25',
+      unitOfMeasure: 'kg',
+      processingType: 'Demo Transformation',
+      processingLineId: 'LINE_DEMO_2',
+      dateProcessed: now.toISOString().slice(0,16),
+      outputBatchId: 'DEMO_OUT_001',
+      expiryDate: exp.toISOString().slice(0,10),
+      destinationDistributorId: distributorAliases[0] || ''
+    });
+    toast({ title: 'Demo data loaded' });
   };
 
   const generateShipmentId = () => {
@@ -90,6 +110,10 @@ const TransformProductsForm: React.FC<TransformProductsFormProps> = ({ shipmentI
           <span>Transform &amp; Create Product</span>
         </CardTitle>
         <CardDescription>Consume this shipment and create a new product</CardDescription>
+        <Button type="button" variant="outline" onClick={fillWithDemoData} className="mt-2 text-sm">
+          <TestTubeDiagonal className="h-4 w-4 mr-2" />
+          Fill with Demo Data
+        </Button>
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit} className="space-y-4">

--- a/application/foodtrace-ledger-supply/src/pages/TransformProductsPage.tsx
+++ b/application/foodtrace-ledger-supply/src/pages/TransformProductsPage.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import Layout from '@/components/Layout';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { TestTubeDiagonal } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
@@ -61,6 +62,25 @@ const TransformProductsPage: React.FC = () => {
 
   const updateProc = (field: keyof typeof procData, val: string)=> setProcData(d=>({...d,[field]:val}));
 
+  const fillWithDemoData = () => {
+    if (consumable.length > 0) {
+      setInputs([{ shipmentId: String(consumable[0].shipmentID || consumable[0].id) }]);
+    }
+    setProducts([{ newShipmentId: '', productName: 'Demo Sauce', description: 'Tasty demo product', quantity: '10', unitOfMeasure: 'kg' }]);
+    const now = new Date();
+    const expiry = new Date();
+    expiry.setDate(now.getDate()+90);
+    setProcData({
+      processingType: 'Blending',
+      processingLineId: 'LINE_DEMO',
+      dateProcessed: now.toISOString().slice(0,16),
+      outputBatchId: 'BATCH_DEMO',
+      expiryDate: expiry.toISOString().slice(0,10),
+      destinationDistributorId: distributorAliases[0] || ''
+    });
+    toast({ title: 'Demo data loaded' });
+  };
+
   const handleSubmit = async (e:React.FormEvent)=>{
     e.preventDefault();
     const selected = inputs.map(i=>i.shipmentId).filter(id=>id);
@@ -103,6 +123,10 @@ const TransformProductsPage: React.FC = () => {
         <Card>
           <CardHeader>
             <CardTitle>Transform Products</CardTitle>
+            <Button type="button" variant="outline" onClick={fillWithDemoData} className="mt-2 text-sm">
+              <TestTubeDiagonal className="h-4 w-4 mr-2" />
+              Fill with Demo Data
+            </Button>
           </CardHeader>
           <CardContent>
             <form onSubmit={handleSubmit} className="space-y-6">


### PR DESCRIPTION
## Summary
- add demo-data helpers to every action form
- show a "Fill with Demo Data" button on forms and transformation page

## Testing
- `npm test` *(fails: no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_683ff78007a8832da240717ad14b7a2a