### PR TITLE
Add GPS data fields

### DIFF
--- a/application/foodtrace-ledger-supply/package.json
+++ b/application/foodtrace-ledger-supply/package.json
@@ -50,6 +50,8 @@
     "next-themes": "^0.3.0",
     "qrcode": "^1.5.4",
     "qrcode.react": "^4.2.0",
+    "leaflet": "^1.9.4",
+    "react-leaflet": "^4.2.1",
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",

--- a/application/foodtrace-ledger-supply/src/components/DistributeShipmentForm.tsx
+++ b/application/foodtrace-ledger-supply/src/components/DistributeShipmentForm.tsx
@@ -33,6 +33,7 @@ const DistributeShipmentForm: React.FC<DistributeShipmentFormProps> = ({
     distributionCenter: '',
     distributionLineId: '',
     transitLocationLog: '',
+    transitGpsLog: '',
     destinationRetailerId: ''
   });
 
@@ -52,6 +53,7 @@ const DistributeShipmentForm: React.FC<DistributeShipmentFormProps> = ({
       distributionCenter: 'Demo DC',
       distributionLineId: 'TRUCK_DEMO_1',
       transitLocationLog: 'Warehouse A, Hub B',
+      transitGpsLog: '37.1,-122.1\n37.2,-122.2',
       destinationRetailerId: retailerAliases[0] || ''
     });
     toast({ title: 'Demo data loaded' });
@@ -102,6 +104,17 @@ const DistributeShipmentForm: React.FC<DistributeShipmentFormProps> = ({
       const transitLocationLogArray = formData.transitLocationLog.trim()
         ? formData.transitLocationLog.split(',').map(location => location.trim()).filter(location => location)
         : [];
+      const transitGpsLogArray = formData.transitGpsLog.trim()
+        ? formData.transitGpsLog.split('\n').map(line => {
+            const [lat, lng] = line.split(',').map(s => s.trim());
+            const latNum = parseFloat(lat);
+            const lngNum = parseFloat(lng);
+            if (!isNaN(latNum) && !isNaN(lngNum)) {
+              return { latitude: latNum, longitude: lngNum };
+            }
+            return null;
+          }).filter(Boolean) as { latitude: number; longitude: number }[]
+        : [];
 
       const payloadForApi = {
         pickupDateTime: pickupDateTimeISO,
@@ -112,6 +125,7 @@ const DistributeShipmentForm: React.FC<DistributeShipmentFormProps> = ({
         distributionCenter: formData.distributionCenter.trim(),
         distributionLineId: formData.distributionLineId.trim(),
         transitLocationLog: transitLocationLogArray,
+        transitGpsLog: transitGpsLogArray,
         destinationRetailerId: formData.destinationRetailerId.trim()
       };
 
@@ -242,6 +256,16 @@ const DistributeShipmentForm: React.FC<DistributeShipmentFormProps> = ({
               value={formData.transitLocationLog}
               onChange={(e) => handleInputChange('transitLocationLog', e.target.value)}
               placeholder="e.g., Warehouse A, Transit Hub B, Distribution Center C"
+              rows={2}
+            />
+          </div>
+          <div>
+            <Label htmlFor="transitGpsLog">Transit GPS Log (lat,lng per line)</Label>
+            <Textarea
+              id="transitGpsLog"
+              value={formData.transitGpsLog}
+              onChange={(e) => handleInputChange('transitGpsLog', e.target.value)}
+              placeholder="37.1,-122.1\n37.2,-122.2"
               rows={2}
             />
           </div>

--- a/application/foodtrace-ledger-supply/src/components/DistributeShipmentForm.tsx
+++ b/application/foodtrace-ledger-supply/src/components/DistributeShipmentForm.tsx
@@ -9,6 +9,7 @@ import { apiClient } from '@/services/api';
 import { useToast } from '@/hooks/use-toast';
 import { useAliases } from '@/hooks/use-aliases';
 import { Truck, X, TestTubeDiagonal } from 'lucide-react';
+import RouteMapInput, { GeoPoint } from './RouteMapInput';
 
 interface DistributeShipmentFormProps {
   shipmentId: string;
@@ -33,11 +34,11 @@ const DistributeShipmentForm: React.FC<DistributeShipmentFormProps> = ({
     distributionCenter: '',
     distributionLineId: '',
     transitLocationLog: '',
-    transitGpsLog: '',
+    transitGpsLog: [] as GeoPoint[],
     destinationRetailerId: ''
   });
 
-  const handleInputChange = (field: keyof typeof formData, value: string) => {
+  const handleInputChange = (field: keyof typeof formData, value: any) => {
     setFormData(prev => ({ ...prev, [field]: value }));
   };
 
@@ -53,7 +54,10 @@ const DistributeShipmentForm: React.FC<DistributeShipmentFormProps> = ({
       distributionCenter: 'Demo DC',
       distributionLineId: 'TRUCK_DEMO_1',
       transitLocationLog: 'Warehouse A, Hub B',
-      transitGpsLog: '37.1,-122.1\n37.2,-122.2',
+      transitGpsLog: [
+        { latitude: 37.1, longitude: -122.1 },
+        { latitude: 37.2, longitude: -122.2 }
+      ],
       destinationRetailerId: retailerAliases[0] || ''
     });
     toast({ title: 'Demo data loaded' });
@@ -104,17 +108,7 @@ const DistributeShipmentForm: React.FC<DistributeShipmentFormProps> = ({
       const transitLocationLogArray = formData.transitLocationLog.trim()
         ? formData.transitLocationLog.split(',').map(location => location.trim()).filter(location => location)
         : [];
-      const transitGpsLogArray = formData.transitGpsLog.trim()
-        ? formData.transitGpsLog.split('\n').map(line => {
-            const [lat, lng] = line.split(',').map(s => s.trim());
-            const latNum = parseFloat(lat);
-            const lngNum = parseFloat(lng);
-            if (!isNaN(latNum) && !isNaN(lngNum)) {
-              return { latitude: latNum, longitude: lngNum };
-            }
-            return null;
-          }).filter(Boolean) as { latitude: number; longitude: number }[]
-        : [];
+      const transitGpsLogArray = formData.transitGpsLog;
 
       const payloadForApi = {
         pickupDateTime: pickupDateTimeISO,
@@ -259,14 +253,11 @@ const DistributeShipmentForm: React.FC<DistributeShipmentFormProps> = ({
               rows={2}
             />
           </div>
-          <div>
-            <Label htmlFor="transitGpsLog">Transit GPS Log (lat,lng per line)</Label>
-            <Textarea
-              id="transitGpsLog"
-              value={formData.transitGpsLog}
-              onChange={(e) => handleInputChange('transitGpsLog', e.target.value)}
-              placeholder="37.1,-122.1\n37.2,-122.2"
-              rows={2}
+          <div className="md:col-span-2 space-y-2">
+            <Label>Transit GPS Log (click map to add points)</Label>
+            <RouteMapInput
+              points={formData.transitGpsLog}
+              onChange={(pts) => handleInputChange('transitGpsLog', pts)}
             />
           </div>
 

--- a/application/foodtrace-ledger-supply/src/components/MapPicker.tsx
+++ b/application/foodtrace-ledger-supply/src/components/MapPicker.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { MapContainer, TileLayer, Marker, useMapEvents } from 'react-leaflet';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+
+L.Icon.Default.imagePath = 'https://unpkg.com/leaflet@1.9.4/dist/images/';
+
+interface MapPickerProps {
+  latitude?: number;
+  longitude?: number;
+  onChange: (lat: number, lng: number) => void;
+}
+
+const MapEvents: React.FC<{ onClick: (lat: number, lng: number) => void }> = ({ onClick }) => {
+  useMapEvents({
+    click(e) {
+      onClick(e.latlng.lat, e.latlng.lng);
+    }
+  });
+  return null;
+};
+
+const MapPicker: React.FC<MapPickerProps> = ({ latitude, longitude, onChange }) => {
+  const center: [number, number] = latitude && longitude ? [latitude, longitude] : [0, 0];
+  return (
+    <MapContainer center={center} zoom={5} style={{ height: '300px', width: '100%' }}>
+      <TileLayer
+        attribution="&copy; OpenStreetMap contributors"
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      />
+      <MapEvents onClick={onChange} />
+      {latitude !== undefined && longitude !== undefined && (
+        <Marker position={[latitude, longitude]} />
+      )}
+    </MapContainer>
+  );
+};
+
+export default MapPicker;

--- a/application/foodtrace-ledger-supply/src/components/RouteMapInput.tsx
+++ b/application/foodtrace-ledger-supply/src/components/RouteMapInput.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { MapContainer, TileLayer, Marker, Polyline, useMapEvents } from 'react-leaflet';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+
+L.Icon.Default.imagePath = 'https://unpkg.com/leaflet@1.9.4/dist/images/';
+
+export interface GeoPoint {
+  latitude: number;
+  longitude: number;
+}
+
+interface RouteMapInputProps {
+  points: GeoPoint[];
+  onChange: (pts: GeoPoint[]) => void;
+}
+
+const MapEvents: React.FC<{ onAdd: (p: GeoPoint) => void }> = ({ onAdd }) => {
+  useMapEvents({
+    click(e) {
+      onAdd({ latitude: e.latlng.lat, longitude: e.latlng.lng });
+    }
+  });
+  return null;
+};
+
+const RouteMapInput: React.FC<RouteMapInputProps> = ({ points, onChange }) => {
+  const coords = points.map(p => [p.latitude, p.longitude]) as [number, number][];
+  const center: [number, number] = coords[0] || [0, 0];
+  const handleAdd = (p: GeoPoint) => {
+    onChange([...points, p]);
+  };
+  return (
+    <MapContainer center={center} zoom={5} style={{ height: '300px', width: '100%' }}>
+      <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" attribution="&copy; OpenStreetMap contributors" />
+      <MapEvents onAdd={handleAdd} />
+      {coords.map((c, i) => (
+        <Marker key={i} position={c} />
+      ))}
+      {coords.length > 1 && <Polyline positions={coords} />}
+    </MapContainer>
+  );
+};
+
+export default RouteMapInput;

--- a/application/foodtrace-ledger-supply/src/components/ShipmentMapView.tsx
+++ b/application/foodtrace-ledger-supply/src/components/ShipmentMapView.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { MapContainer, TileLayer, Marker, Polyline } from 'react-leaflet';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import { GeoPoint } from './RouteMapInput';
+
+L.Icon.Default.imagePath = 'https://unpkg.com/leaflet@1.9.4/dist/images/';
+
+interface ShipmentMapViewProps {
+  farmLocation?: GeoPoint;
+  route?: GeoPoint[];
+}
+
+const ShipmentMapView: React.FC<ShipmentMapViewProps> = ({ farmLocation, route }) => {
+  const farmCoord = farmLocation ? [farmLocation.latitude, farmLocation.longitude] as [number, number] : undefined;
+  const routeCoords = route ? route.map(p => [p.latitude, p.longitude]) as [number, number][] : [];
+  const center: [number, number] = farmCoord || routeCoords[0] || [0, 0];
+
+  return (
+    <MapContainer center={center} zoom={5} style={{ height: '300px', width: '100%' }}>
+      <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" attribution="&copy; OpenStreetMap contributors" />
+      {farmCoord && <Marker position={farmCoord} />}
+      {routeCoords.map((c, i) => <Marker key={i} position={c} />)}
+      {routeCoords.length > 1 && <Polyline positions={routeCoords} />}
+    </MapContainer>
+  );
+};
+
+export default ShipmentMapView;

--- a/application/foodtrace-ledger-supply/src/main.tsx
+++ b/application/foodtrace-ledger-supply/src/main.tsx
@@ -1,5 +1,6 @@
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
+import 'leaflet/dist/leaflet.css'
 
 createRoot(document.getElementById("root")!).render(<App />);

--- a/application/foodtrace-ledger-supply/src/pages/CreateShipment.tsx
+++ b/application/foodtrace-ledger-supply/src/pages/CreateShipment.tsx
@@ -11,6 +11,7 @@ import { apiClient } from '@/services/api';
 import { useAliases } from '@/hooks/use-aliases';
 import { useToast } from '@/hooks/use-toast';
 import { ArrowLeft, Package, TestTubeDiagonal } from 'lucide-react'; // Added TestTubeDiagonal for demo button
+import MapPicker from '@/components/MapPicker';
 
 const CreateShipment = () => {
   const navigate = useNavigate();
@@ -317,26 +318,15 @@ const CreateShipment = () => {
                     placeholder="City, State/Province, Country"
                   />
                 </div>
-                <div>
-                  <Label htmlFor="farmLatitude">Latitude *</Label>
-                  <Input
-                    id="farmLatitude"
-                    type="number"
-                    step="0.0001"
-                    value={formData.farmLatitude}
-                    onChange={(e) => handleInputChange('farmLatitude', e.target.value)}
-                    placeholder="e.g., 37.7749"
-                  />
-                </div>
-                <div>
-                  <Label htmlFor="farmLongitude">Longitude *</Label>
-                  <Input
-                    id="farmLongitude"
-                    type="number"
-                    step="0.0001"
-                    value={formData.farmLongitude}
-                    onChange={(e) => handleInputChange('farmLongitude', e.target.value)}
-                    placeholder="e.g., -122.4194"
+                <div className="md:col-span-2 space-y-2">
+                  <Label>Farm Coordinates (click to place marker)</Label>
+                  <MapPicker
+                    latitude={formData.farmLatitude ? parseFloat(formData.farmLatitude) : undefined}
+                    longitude={formData.farmLongitude ? parseFloat(formData.farmLongitude) : undefined}
+                    onChange={(lat, lng) => {
+                      handleInputChange('farmLatitude', lat.toFixed(5));
+                      handleInputChange('farmLongitude', lng.toFixed(5));
+                    }}
                   />
                 </div>
               </div>

--- a/application/foodtrace-ledger-supply/src/pages/CreateShipment.tsx
+++ b/application/foodtrace-ledger-supply/src/pages/CreateShipment.tsx
@@ -25,6 +25,8 @@ const CreateShipment = () => {
     unitOfMeasure: 'kg',
     farmerName: '',
     farmLocation: '',
+    farmLatitude: '',
+    farmLongitude: '',
     cropType: '',
     plantingDate: '', // Store as YYYY-MM-DD string from date picker
     harvestDate: '',   // Store as YYYY-MM-DD string from date picker
@@ -69,6 +71,8 @@ const CreateShipment = () => {
       unitOfMeasure: 'kg',
       farmerName: 'Demo Apple Farms Co.',
       farmLocation: 'Green Valley, CA, USA',
+      farmLatitude: '37.0000',
+      farmLongitude: '-122.0000',
       cropType: 'Apples (Fuji)',
       plantingDate: formatDateForInput(planting),
       harvestDate: formatDateForInput(harvest),
@@ -117,6 +121,10 @@ const CreateShipment = () => {
       toast({ title: "Validation Error", description: "Farm Location is required.", variant: "destructive" });
       setLoading(false); return;
     }
+    if (!formData.farmLatitude.trim() || !formData.farmLongitude.trim()) {
+      toast({ title: "Validation Error", description: "Farm GPS coordinates are required.", variant: "destructive" });
+      setLoading(false); return;
+    }
 
     const quantityValue = parseFloat(formData.quantity);
     if (isNaN(quantityValue) || quantityValue <= 0) {
@@ -141,6 +149,10 @@ const CreateShipment = () => {
       const farmerData = {
         farmerName: formData.farmerName.trim(),
         farmLocation: formData.farmLocation.trim(),
+        farmCoordinates: {
+          latitude: parseFloat(formData.farmLatitude),
+          longitude: parseFloat(formData.farmLongitude)
+        },
         cropType: formData.cropType.trim(),
         plantingDate: plantingDateISO,
         harvestDate: harvestDateISO,
@@ -303,6 +315,28 @@ const CreateShipment = () => {
                     value={formData.farmLocation}
                     onChange={(e) => handleInputChange('farmLocation', e.target.value)}
                     placeholder="City, State/Province, Country"
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="farmLatitude">Latitude *</Label>
+                  <Input
+                    id="farmLatitude"
+                    type="number"
+                    step="0.0001"
+                    value={formData.farmLatitude}
+                    onChange={(e) => handleInputChange('farmLatitude', e.target.value)}
+                    placeholder="e.g., 37.7749"
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="farmLongitude">Longitude *</Label>
+                  <Input
+                    id="farmLongitude"
+                    type="number"
+                    step="0.0001"
+                    value={formData.farmLongitude}
+                    onChange={(e) => handleInputChange('farmLongitude', e.target.value)}
+                    placeholder="e.g., -122.4194"
                   />
                 </div>
               </div>

--- a/application/foodtrace-ledger-supply/src/pages/PublicTracker.tsx
+++ b/application/foodtrace-ledger-supply/src/pages/PublicTracker.tsx
@@ -323,6 +323,12 @@ const PublicTracker = () => {
                       <label className="text-sm font-medium text-gray-500">Location</label>
                       <p className="text-gray-900 mt-1">{shipment.farmerData.farmLocation}</p>
                     </div>
+                    {shipment.farmerData.farmCoordinates && (
+                      <div>
+                        <label className="text-sm font-medium text-gray-500">GPS</label>
+                        <p className="text-gray-900 mt-1">{shipment.farmerData.farmCoordinates.latitude}, {shipment.farmerData.farmCoordinates.longitude}</p>
+                      </div>
+                    )}
                     <div>
                       <label className="text-sm font-medium text-gray-500">Farming Practice</label>
                       <Badge variant="secondary" className="mt-1">
@@ -423,6 +429,14 @@ const PublicTracker = () => {
                       <label className="text-sm font-medium text-gray-500">Vehicle ID</label>
                       <p className="text-gray-900 mt-1">{shipment.distributorData.distributionLineId}</p>
                     </div>
+                    {shipment.distributorData.transitGpsLog && shipment.distributorData.transitGpsLog.length > 0 && (
+                      <div className="md:col-span-2">
+                        <label className="text-sm font-medium text-gray-500">GPS Log</label>
+                        <p className="text-gray-900 mt-1 break-words">
+                          {shipment.distributorData.transitGpsLog.map(g => `${g.latitude},${g.longitude}`).join(' | ')}
+                        </p>
+                      </div>
+                    )}
                   </div>
                 </CardContent>
               </Card>

--- a/application/foodtrace-ledger-supply/src/pages/PublicTracker.tsx
+++ b/application/foodtrace-ledger-supply/src/pages/PublicTracker.tsx
@@ -20,6 +20,7 @@ import {
   Home,
   ArrowLeft
 } from 'lucide-react';
+import ShipmentMapView from '@/components/ShipmentMapView';
 
 interface TimelineStep {
   key: string;
@@ -260,6 +261,23 @@ const PublicTracker = () => {
                 </div>
               </CardContent>
             </Card>
+
+            {(shipment.farmerData?.farmCoordinates || (shipment.distributorData && shipment.distributorData.transitGpsLog.length > 0)) && (
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center space-x-2">
+                    <MapPin className="h-5 w-5" />
+                    <span>Route Map</span>
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <ShipmentMapView
+                    farmLocation={shipment.farmerData?.farmCoordinates}
+                    route={shipment.distributorData?.transitGpsLog}
+                  />
+                </CardContent>
+              </Card>
+            )}
 
             {/* Supply Chain Timeline */}
             <Card>

--- a/application/foodtrace-ledger-supply/src/pages/ShipmentDetails.tsx
+++ b/application/foodtrace-ledger-supply/src/pages/ShipmentDetails.tsx
@@ -18,6 +18,7 @@ import ReceiveShipmentForm from '@/components/ReceiveShipmentForm';
 import RecordCertificationForm from '@/components/RecordCertificationForm';
 import RecallForm from '@/components/RecallForm';
 import ArchiveShipmentForm from '@/components/ArchiveShipmentForm';
+import ShipmentMapView from '@/components/ShipmentMapView';
 import TransformProductsForm from '@/components/TransformProductsForm';
 import QrCodeDisplay from '@/components/QrCodeDisplay';
 
@@ -306,6 +307,18 @@ const ShipmentDetails = () => {
               <DetailItem label="Created At" value={formatDate(shipment.createdAt)} />
             </CardContent>
           </Card>
+
+          {(shipment.farmerData?.farmCoordinates || (shipment.distributorData && shipment.distributorData.transitGpsLog.length > 0)) && (
+            <Card>
+              <CardHeader><CardTitle className="flex items-center space-x-2"><MapPin className="h-5 w-5" /><span>Route Map</span></CardTitle></CardHeader>
+              <CardContent>
+                <ShipmentMapView
+                  farmLocation={shipment.farmerData?.farmCoordinates}
+                  route={shipment.distributorData?.transitGpsLog}
+                />
+              </CardContent>
+            </Card>
+          )}
 
           {shipment.farmerData && (
             <Card>

--- a/application/foodtrace-ledger-supply/src/pages/ShipmentDetails.tsx
+++ b/application/foodtrace-ledger-supply/src/pages/ShipmentDetails.tsx
@@ -313,6 +313,9 @@ const ShipmentDetails = () => {
               <CardContent className="space-y-3">
                 <DetailItem label="Farm Name" value={shipment.farmerData.farmerName} />
                 <DetailItem label="Location" value={shipment.farmerData.farmLocation} />
+                {shipment.farmerData.farmCoordinates && (
+                  <DetailItem label="GPS" value={`${shipment.farmerData.farmCoordinates.latitude}, ${shipment.farmerData.farmCoordinates.longitude}`} />
+                )}
                 <DetailItem label="Crop Type" value={shipment.farmerData.cropType} />
                 <DetailItem label="Farming Practice" value={shipment.farmerData.farmingPractice} />
                 <DetailItem label="Planting Date" value={formatDate(shipment.farmerData.plantingDate)} />
@@ -353,6 +356,9 @@ const ShipmentDetails = () => {
                 <DetailItem label="Transport Conditions" value={shipment.distributorData.transportConditions} />
                 <DetailItem label="Distribution Center" value={shipment.distributorData.distributionCenter} />
                 <DetailItem label="Transit Log" value={Array.isArray(shipment.distributorData.transitLocationLog) ? shipment.distributorData.transitLocationLog.join(', ') : shipment.distributorData.transitLocationLog} />
+                {shipment.distributorData.transitGpsLog && shipment.distributorData.transitGpsLog.length > 0 && (
+                  <DetailItem label="GPS Log" value={shipment.distributorData.transitGpsLog.map(g => `${g.latitude},${g.longitude}`).join(' | ')} />
+                )}
                 <DetailItem label="Destination Retailer ID" value={shipment.distributorData.destinationRetailerId} />
               </CardContent>
             </Card>

--- a/chaincode/contract/shipment_distributor_ops.go
+++ b/chaincode/contract/shipment_distributor_ops.go
@@ -55,6 +55,7 @@ func (s *FoodtraceSmartContract) DistributeShipment(ctx contractapi.TransactionC
 		TemperatureRange:      ddArgs.TemperatureRange,
 		StorageTemperature:    ddArgs.StorageTemperature,
 		TransitLocationLog:    ddArgs.TransitLocationLog,
+		TransitGPSLog:         ddArgs.TransitGPSLog,
 		TransportConditions:   ddArgs.TransportConditions,
 		DistributionCenter:    ddArgs.DistributionCenter,
 		DestinationRetailerID: destRetFullID,

--- a/chaincode/contract/shipment_farmer_ops.go
+++ b/chaincode/contract/shipment_farmer_ops.go
@@ -83,6 +83,7 @@ func (s *FoodtraceSmartContract) CreateShipment(ctx contractapi.TransactionConte
 			FarmerAlias:               actor.alias,
 			FarmerName:                fdArgs.FarmerName,
 			FarmLocation:              fdArgs.FarmLocation,
+			FarmCoordinates:           fdArgs.FarmCoordinates,
 			CropType:                  fdArgs.CropType,
 			PlantingDate:              fdArgs.PlantingDate,
 			FertilizerUsed:            fdArgs.FertilizerUsed,

--- a/chaincode/model/shipments.go
+++ b/chaincode/model/shipments.go
@@ -27,12 +27,19 @@ const (
 	CertStatusRejected CertificationStatus = "REJECTED"
 )
 
+// GeoPoint represents a latitude/longitude coordinate.
+type GeoPoint struct {
+	Latitude  float64 `json:"latitude"`
+	Longitude float64 `json:"longitude"`
+}
+
 // FarmerData holds information specific to the farming stage.
 type FarmerData struct {
 	FarmerID                  string    `json:"farmerId"`
 	FarmerName                string    `json:"farmerName"`
 	FarmerAlias               string    `json:"farmerAlias"`
 	FarmLocation              string    `json:"farmLocation"`
+	FarmCoordinates           *GeoPoint `json:"farmCoordinates"`
 	CropType                  string    `json:"cropType"`
 	PlantingDate              time.Time `json:"plantingDate"`
 	FertilizerUsed            string    `json:"fertilizerUsed"`
@@ -72,17 +79,18 @@ type CertificationRecord struct {
 
 // DistributorData holds information specific to the distribution stage.
 type DistributorData struct {
-	DistributorID         string    `json:"distributorId"`
-	DistributorAlias      string    `json:"distributorAlias"`
-	PickupDateTime        time.Time `json:"pickupDateTime"`
-	DeliveryDateTime      time.Time `json:"deliveryDateTime"`
-	DistributionLineID    string    `json:"distributionLineId"`
-	TemperatureRange      string    `json:"temperatureRange"`
-	StorageTemperature    float64   `json:"storageTemperature"`
-	TransitLocationLog    []string  `json:"transitLocationLog"`
-	TransportConditions   string    `json:"transportConditions"`
-	DistributionCenter    string    `json:"distributionCenter"`
-	DestinationRetailerID string    `json:"destinationRetailerId"`
+	DistributorID         string     `json:"distributorId"`
+	DistributorAlias      string     `json:"distributorAlias"`
+	PickupDateTime        time.Time  `json:"pickupDateTime"`
+	DeliveryDateTime      time.Time  `json:"deliveryDateTime"`
+	DistributionLineID    string     `json:"distributionLineId"`
+	TemperatureRange      string     `json:"temperatureRange"`
+	StorageTemperature    float64    `json:"storageTemperature"`
+	TransitLocationLog    []string   `json:"transitLocationLog"`
+	TransitGPSLog         []GeoPoint `json:"transitGpsLog"`
+	TransportConditions   string     `json:"transportConditions"`
+	DistributionCenter    string     `json:"distributionCenter"`
+	DestinationRetailerID string     `json:"destinationRetailerId"`
 }
 
 // RetailerData holds information specific to the retail stage.
@@ -127,7 +135,7 @@ type Shipment struct {
 	LastUpdatedAt        time.Time             `json:"lastUpdatedAt"`
 	IsArchived           bool                  `json:"isArchived"`
 	InputShipmentIDs     []string              `json:"inputShipmentIds"` // IDs of shipments consumed to create this one
-	IsDerivedProduct     bool                  `json:"isDerivedProduct"`           // True if this shipment was created from other input shipments
+	IsDerivedProduct     bool                  `json:"isDerivedProduct"` // True if this shipment was created from other input shipments
 	FarmerData           *FarmerData           `json:"farmerData"`
 	CertificationRecords []CertificationRecord `json:"certificationRecords"`
 	ProcessorData        *ProcessorData        `json:"processorData"`
@@ -142,7 +150,7 @@ type HistoryEntry struct {
 	TxID       string    `json:"txId"`
 	Timestamp  time.Time `json:"timestamp"`
 	IsDelete   bool      `json:"isDelete"`
-	Value      string    `json:"value"`                // Raw JSON value of the asset at that time
+	Value      string    `json:"value"`      // Raw JSON value of the asset at that time
 	ActorID    string    `json:"actorId"`    // Best guess of the actor based on CurrentOwnerID at the time
 	ActorAlias string    `json:"actorAlias"` // Best guess of the actor's alias
 	Action     string    `json:"action"`     // Description of the action (e.g., status change)
@@ -158,8 +166,8 @@ type RelatedShipmentInfo struct {
 	RelationReason    string         `json:"relationReason"`
 	ActorID           string         `json:"actorId"` // ID of the actor involved in the related event (e.g., processor)
 	ActorAlias        string         `json:"actorAlias"`
-	LineID            string         `json:"lineId"` // e.g., processingLineId or distributionLineId
-	EventTimestamp    time.Time      `json:"eventTimestamp"`   // Timestamp of the relating event (e.g., DateProcessed)
+	LineID            string         `json:"lineId"`         // e.g., processingLineId or distributionLineId
+	EventTimestamp    time.Time      `json:"eventTimestamp"` // Timestamp of the relating event (e.g., DateProcessed)
 }
 
 // InputShipmentConsumptionDetail defines the ID of an input shipment to be fully consumed.


### PR DESCRIPTION
## Summary
- define `GeoPoint` type for lat/long coordinates
- store farm coordinates and distribution GPS logs in ledger models
- validate geo point input in chaincode helpers
- include GPS data in farmer and distributor operations
- extend frontend forms and detail pages to handle GPS fields

## Testing
- `go build ./...`
- `npm run lint` *(fails: cannot find module '@eslint/js')*
- `npm test` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_e_684130c990f8832d815afaa7f3784d98